### PR TITLE
Fix spelling errors in boxbg.js

### DIFF
--- a/cssPaint/intro/worklets/boxbg.js
+++ b/cssPaint/intro/worklets/boxbg.js
@@ -4,15 +4,15 @@ registerPaint('boxbg', class {
   static get contextOptions() { return {alpha: true}; }
 
    // use this function to retrieve any custom props defined for the element, return them in the specified array
-  static get inputProperties() { return ['--boxColor', '--widthSubtractor']; }
+  static get inputProperties() { return ['--box-color', '--width-subtractor']; }
 
   paint(ctx, size, props) {
     // ctx -> drawing context
     // size -> paintSize: width and height
     // props -> properties: get() method
 
-		ctx.fillStyle = props.get('--boxColor'); 
-		ctx.fillRect(0, size.height/3, size.width*0.4 - props.get('--widthSubtractor'), size.height*0.6);
+		ctx.fillStyle = props.get('--box-color'); 
+		ctx.fillRect(0, size.height/3, size.width*0.4 - props.get('--width-subtractor'), size.height*0.6);
 
   }
 });


### PR DESCRIPTION
The `inputProperties` in the boxbg.js paint worklet should match the CSS property names *exactly* for it to work. I tested this myself, overriding the example file in DevTools to this version and running the example at the page on [CSS Painting API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Painting_API), and it only works as intended after I override the file to this new version.